### PR TITLE
Fix for Pawnshop Exploit

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -3,6 +3,7 @@ local Translations = {
         negative = 'Trying to sell a negative amount?',
         no_melt = 'You didn\'t give me anything to melt...',
         no_items = 'Not enough items',
+        inventory_full = 'Inventory too full to receive all possible items. Try making sure inventory isn\'t full next time. Items Lost: %{value}'
     },
     success = {
         sold = 'You have sold %{value} x %{value2} for $%{value3}',

--- a/server/main.lua
+++ b/server/main.lua
@@ -78,7 +78,7 @@ RegisterNetEvent('qb-pawnshop:server:pickupMelted', function(item)
                 TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[m.item], 'add')
                 TriggerClientEvent('QBCore:Notify', src, Lang:t('success.items_received',{ value = (meltedAmount * rewardAmount), value2 = QBCore.Shared.Items[m.item].label }), 'success')
             else
-                TriggerClientEvent('QBCore:Notify', src, 'Inventory Was too full to recieve all possible items. Try making sure your inventory isn\'t full next time. Items Lost: '..QBCore.Shared.Items[m.item].label, 'warning', 7500)
+                TriggerClientEvent('QBCore:Notify', src, Lang:t('inventory_full', { value = QBCore.Shared.Items[m.item].label}), 'warning', 7500)
             end
         end
     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -79,8 +79,6 @@ RegisterNetEvent('qb-pawnshop:server:pickupMelted', function(item)
                 TriggerClientEvent('QBCore:Notify', src, Lang:t('success.items_received',{ value = (meltedAmount * rewardAmount), value2 = QBCore.Shared.Items[m.item].label }), 'success')
             else
                 TriggerClientEvent('QBCore:Notify', src, 'Inventory Was too full to recieve all possible items. Try making sure your inventory isn\'t full next time. Items Lost: '..QBCore.Shared.Items[m.item].label, 'warning', 7500)
-                --TriggerClientEvent('qb-pawnshop:client:openMenu', src)
-                --return
             end
         end
     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -78,7 +78,7 @@ RegisterNetEvent('qb-pawnshop:server:pickupMelted', function(item)
                 TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[m.item], 'add')
                 TriggerClientEvent('QBCore:Notify', src, Lang:t('success.items_received',{ value = (meltedAmount * rewardAmount), value2 = QBCore.Shared.Items[m.item].label }), 'success')
             else
-                TriggerClientEvent('QBCore:Notify', src, Lang:t('inventory_full', { value = QBCore.Shared.Items[m.item].label}), 'warning', 7500)
+                TriggerClientEvent('QBCore:Notify', src, Lang:t('error.inventory_full', { value = QBCore.Shared.Items[m.item].label}), 'warning', 7500)
             end
         end
     end

--- a/server/main.lua
+++ b/server/main.lua
@@ -78,8 +78,9 @@ RegisterNetEvent('qb-pawnshop:server:pickupMelted', function(item)
                 TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[m.item], 'add')
                 TriggerClientEvent('QBCore:Notify', src, Lang:t('success.items_received',{ value = (meltedAmount * rewardAmount), value2 = QBCore.Shared.Items[m.item].label }), 'success')
             else
-                TriggerClientEvent('qb-pawnshop:client:openMenu', src)
-                return
+                TriggerClientEvent('QBCore:Notify', src, 'Inventory Was too full to recieve all possible items. Try making sure your inventory isn\'t full next time. Items Lost: '..QBCore.Shared.Items[m.item].label, 'warning', 7500)
+                --TriggerClientEvent('qb-pawnshop:client:openMenu', src)
+                --return
             end
         end
     end


### PR DESCRIPTION
**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

The current issue is, if players inventory slots are full except 1 or so, and they smelt an item that can give them multiple items back, then when the item is smelted and they can press the pickup smelted items button, it will give them the first item but isn't able to give the rest of the items, but takes them back to the menu with the pickup smelted items button. They can continue spamming the button to get as many of the first item as they desire. 
With this fix, It will make it so that button disappears and they cant get the rest of the items because of their inventory being full. It also Notifys them of the items they missed because of their inventory being too full.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? YES
- Does your code fit the style guidelines? YES
- Does your PR fit the contribution guidelines? YES
