### PR TITLE
multiple pawnshop locations

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -8,15 +8,17 @@ local ped = {}
 
 CreateThread(function()
     for _, value in pairs(Config.PawnLocation) do
-        local blip = AddBlipForCoord(value.coords.x, value.coords.y, value.coords.z)
-        SetBlipSprite(blip, 431)
-        SetBlipDisplay(blip, 4)
-        SetBlipScale(blip, 0.7)
-        SetBlipAsShortRange(blip, true)
-        SetBlipColour(blip, 5)
-        BeginTextCommandSetBlipName('STRING')
-        AddTextComponentSubstringPlayerName(Lang:t('info.title'))
-        EndTextCommandSetBlipName(blip)
+        if value.showblip then
+            local blip = AddBlipForCoord(value.coords.x, value.coords.y, value.coords.z)
+            SetBlipSprite(blip, 431)
+            SetBlipDisplay(blip, 4)
+            SetBlipScale(blip, 0.7)
+            SetBlipAsShortRange(blip, true)
+            SetBlipColour(blip, 5)
+            BeginTextCommandSetBlipName('STRING')
+            AddTextComponentSubstringPlayerName(Lang:t('info.title'))
+            EndTextCommandSetBlipName(blip)
+        end
     end
 end)
 
@@ -214,11 +216,13 @@ RegisterNetEvent('qb-pawnshop:client:openPawn', function(data)
                 }
             }
         else
-            pawnMenu[#pawnMenu + 1] = {
-                header = QBCore.Shared.Items[v.item].label,
-                txt = Lang:t('info.sell_items', { value = v.price }),
-                disabled = true,
-            }
+            if Config.ShowNotOwnedItems then
+                pawnMenu[#pawnMenu + 1] = {
+                    header = QBCore.Shared.Items[v.item].label,
+                    txt = Lang:t('info.sell_items', { value = v.price }),
+                    disabled = true,
+                }
+            end
         end
     end
 
@@ -272,10 +276,10 @@ RegisterNetEvent('qb-pawnshop:client:openMelt', function(data)
     end)
 end)
 
-RegisterNetEvent('qb-pawnshop:client:pawnitems', function(item)
+RegisterNetEvent('qb-pawnshop:client:pawnitems', function(data)
     QBCore.Functions.TriggerCallback('qb-pawnshop:server:ItemAmount', function(amount)
         local sellingItem = exports['qb-input']:ShowInput({
-            header = "<center><p><img src=nui://"..Config.img..QBCore.Shared.Items[item.name].image.." width=100px></p>"..QBCore.Shared.Items[item.name].label,
+            header = "<center><p><img src=nui://"..Config.img..QBCore.Shared.Items[data.name].image.." width=100px></p>"..QBCore.Shared.Items[data.name].label,
             submitText = Lang:t('info.sell'),
             inputs = {
                 {
@@ -292,12 +296,12 @@ RegisterNetEvent('qb-pawnshop:client:pawnitems', function(item)
             end
 
             if tonumber(sellingItem.amount) > 0 then
-                TriggerServerEvent('qb-pawnshop:server:sellPawnItems', item.name, sellingItem.amount, item.price)
+                TriggerServerEvent('qb-pawnshop:server:sellPawnItems', data.name, sellingItem.amount, data.price)
             else
                 QBCore.Functions.Notify(Lang:t('error.negative'), 'error')
             end
         end
-    end, item.name)
+    end, data.name)
 end)
 
 RegisterNetEvent('qb-pawnshop:client:meltItems', function(item)

--- a/client/main.lua
+++ b/client/main.lua
@@ -70,7 +70,7 @@ CreateThread(function()
             })
         end
         local pawnShopCombo = ComboZone:Create( zone, { name = 'NewPawnShopCombo', debugPoly = false })
-        pawnShopCombo:onPlayerInOut(function(isPointInside, _, zone)
+        pawnShopCombo:onPlayerInOut(function(isPointInside, _, zonedata)
             if isPointInside then
                 exports['qb-menu']:showHeader({
                     {
@@ -78,7 +78,7 @@ CreateThread(function()
                         txt = Lang:t('info.open_pawn'),
                         params = {
                             event = 'qb-pawnshop:client:openMenu',
-                            args = {shopitems = zone.data.shopitems, meltingenabled = zone.data.meltingenabled}
+                            args = {shopitems = zonedata.data.shopitems, meltingenabled = zonedata.data.meltingenabled}
                         },
                     }
                 })

--- a/client/main.lua
+++ b/client/main.lua
@@ -152,7 +152,8 @@ RegisterNetEvent('qb-pawnshop:client:openMenu', function(data)
                 params = {
                     event = 'qb-pawnshop:client:openPawn',
                     args = {
-                        items = shopitems
+                        items = shopitems,
+                        enablemelting = data.meltingenabled
                     }
                 }
             }
@@ -225,7 +226,7 @@ RegisterNetEvent('qb-pawnshop:client:openPawn', function(data)
         header = Lang:t('info.back'),
         params = {
             event = 'qb-pawnshop:client:openMenu',
-            args = {shopitems = shopitems}
+            args = {shopitems = shopitems, meltingenabled = data.enablemelting}
         }
     }
     exports['qb-menu']:openMenu(pawnMenu)

--- a/config.lua
+++ b/config.lua
@@ -1,60 +1,72 @@
 Config = {}
 
+Config.img = "qb-inventory/html/images/"
 Config.PawnLocation = {
     [1] = {
-            coords = vector3(412.34, 314.81, 103.13),
-            length = 1.5,
-            width = 1.8,
-            heading = 207.0,
-            debugPoly = false,
-            minZ = 100.97,
-            maxZ = 105.42,
-            distance = 3.0
-        },
+        coords = vector3(412.34, 314.81, 103.13),
+        length = 1.0,
+        width = 1.0,
+        heading = 207.0,
+        debugPoly = false,
+        distance = 3.0,
+        ped = 'a_f_y_soucent_01',
+        enablemelting = false, -- is melting available at this location ?
+        items = {
+            [1] = {
+                item = 'goldchain',
+                price = math.random(50,100)
+            },
+            [2] = {
+                item = 'diamond_ring',
+                price = math.random(50,100)
+            },
+            [3] = {
+                item = 'rolex',
+                price = math.random(50,100)
+            },
+            [4] = {
+                item = '10kgoldchain',
+                price = math.random(50,100)
+            },
+        }
+    },
+    [2] = {
+        coords = vector3(398.76, 316.85, 103.02),
+        length = 1.0,
+        width = 1.0,
+        heading = 164.25,
+        debugPoly = false,
+        distance = 3.0,
+        ped = 'a_m_o_genstreet_01',
+        enablemelting = true,
+        items = {
+            [1] = {
+                item = 'tablet',
+                price = math.random(50,100)
+            },
+            [2] = {
+                item = 'iphone',
+                price = math.random(50,100)
+            },
+            [3] = {
+                item = 'samsungphone',
+                price = math.random(50,100)
+            },
+            [4] = {
+                item = 'laptop',
+                price = math.random(50,100)
+            }
+        }
+    },
     }
 
 Config.BankMoney = false -- Set to true if you want the money to go into the players bank
 Config.UseTimes = false -- Set to false if you want the pawnshop open 24/7
 Config.TimeOpen = 7 -- Opening Time
 Config.TimeClosed = 17 -- Closing Time
-Config.SendMeltingEmail = true
+Config.SendMeltingEmail = true -- send email when melting is ready ?
 
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true'
-
-Config.PawnItems = {
-    [1] = {
-        item = 'goldchain',
-        price = math.random(50,100)
-    },
-    [2] = {
-        item = 'diamond_ring',
-        price = math.random(50,100)
-    },
-    [3] = {
-        item = 'rolex',
-        price = math.random(50,100)
-    },
-    [4] = {
-        item = '10kgoldchain',
-        price = math.random(50,100)
-    },
-    [5] = {
-        item = 'tablet',
-        price = math.random(50,100)
-    },
-    [6] = {
-        item = 'iphone',
-        price = math.random(50,100)
-    },
-    [7] = {
-        item = 'samsungphone',
-        price = math.random(50,100)
-    },
-    [8] = {
-        item = 'laptop',
-        price = math.random(50,100)
-    }
-}
 
 Config.MeltingItems = { -- meltTime is amount of time in minutes per item
     [1] = {

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,14 @@
 Config = {}
 
 Config.img = "qb-inventory/html/images/"
+Config.UseTarget = GetConvar('UseTarget', 'false') == 'true'
+Config.BankMoney = false -- Set to true if you want the money to go into the players bank
+Config.UseTimes = false -- Set to false if you want the pawnshop open 24/7
+Config.TimeOpen = 7 -- Opening Time
+Config.TimeClosed = 17 -- Closing Time
+Config.SendMeltingEmail = true -- send email when melting is ready ?
+Config.ShowNotOwnedItems = false -- true = Show all items that can be sold, false = Show only owned items
+
 Config.PawnLocation = {
     [1] = {
         coords = vector3(412.34, 314.81, 103.13),
@@ -11,6 +19,7 @@ Config.PawnLocation = {
         distance = 3.0,
         ped = 'a_f_y_soucent_01',
         enablemelting = false, -- is melting available at this location ?
+        showblip = true,
         items = {
             [1] = {
                 item = 'goldchain',
@@ -39,6 +48,7 @@ Config.PawnLocation = {
         distance = 3.0,
         ped = 'a_m_o_genstreet_01',
         enablemelting = true,
+        showblip = false,
         items = {
             [1] = {
                 item = 'tablet',
@@ -58,15 +68,7 @@ Config.PawnLocation = {
             }
         }
     },
-    }
-
-Config.BankMoney = false -- Set to true if you want the money to go into the players bank
-Config.UseTimes = false -- Set to false if you want the pawnshop open 24/7
-Config.TimeOpen = 7 -- Opening Time
-Config.TimeClosed = 17 -- Closing Time
-Config.SendMeltingEmail = true -- send email when melting is ready ?
-
-Config.UseTarget = GetConvar('UseTarget', 'false') == 'true'
+}
 
 Config.MeltingItems = { -- meltTime is amount of time in minutes per item
     [1] = {

--- a/server/main.lua
+++ b/server/main.lua
@@ -41,7 +41,6 @@ RegisterNetEvent('qb-pawnshop:server:sellPawnItems', function(itemName, itemAmou
     else
         TriggerClientEvent('QBCore:Notify', src, Lang:t('error.no_items'), 'error')
     end
-    TriggerClientEvent('qb-pawnshop:client:openMenu', src)
 end)
 
 RegisterNetEvent('qb-pawnshop:server:meltItemRemove', function(itemName, itemAmount, item)
@@ -83,7 +82,6 @@ RegisterNetEvent('qb-pawnshop:server:pickupMelted', function(item)
         end
     end
     TriggerClientEvent('qb-pawnshop:client:resetPickup', src)
-    TriggerClientEvent('qb-pawnshop:client:openMenu', src)
 end)
 
 QBCore.Functions.CreateCallback('qb-pawnshop:server:getInv', function(source, cb)

--- a/server/main.lua
+++ b/server/main.lua
@@ -91,3 +91,15 @@ QBCore.Functions.CreateCallback('qb-pawnshop:server:getInv', function(source, cb
     local inventory = Player.PlayerData.items
     return cb(inventory)
 end)
+
+QBCore.Functions.CreateCallback('qb-pawnshop:server:ItemAmount', function(source, cb, item)
+    local Player = QBCore.Functions.GetPlayer(source)
+    local inventory = Player.PlayerData.items
+    local amount = 0
+    for _,v in pairs(inventory) do
+        if item == v.name then
+            amount = amount + v.amount
+        end
+    end
+    return cb(amount)
+end)


### PR DESCRIPTION
This PR will add the next features to the pawnshop :

1. Multiple locations for pawnshops
2. Each pawnshop will have their own items that can be sold
3. Configurable option to enable melting at the location
4. It will show the items that can be sold at that location and disable the option if you don't have the item on you

See the next video : https://www.youtube.com/watch?v=e4ECV8iKzlA

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [Yes]
- Does your code fit the style guidelines? [Yes]
- Does your PR fit the contribution guidelines? [Yes]
