### PR TITLE
Prevent selling more than player has

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -258,7 +258,7 @@ RegisterNetEvent('qb-pawnshop:client:pawnitems', function(item)
             return
         end
 
-        if tonumber(sellingItem.amount) > 0 then 
+        if tonumber(sellingItem.amount) > 0 then
             if tonumber(sellingItem.amount) <= item.amount then
                 TriggerServerEvent('qb-pawnshop:server:sellPawnItems', item.name, sellingItem.amount, item.price)
             else

--- a/client/main.lua
+++ b/client/main.lua
@@ -258,13 +258,18 @@ RegisterNetEvent('qb-pawnshop:client:pawnitems', function(item)
             return
         end
 
-        if tonumber(sellingItem.amount) > 0 then
-            TriggerServerEvent('qb-pawnshop:server:sellPawnItems', item.name, sellingItem.amount, item.price)
+        if tonumber(sellingItem.amount) > 0 then 
+            if tonumber(sellingItem.amount) <= item.amount then
+                TriggerServerEvent('qb-pawnshop:server:sellPawnItems', item.name, sellingItem.amount, item.price)
+            else
+                QBCore.Functions.Notify(Lang:t('error.no_items'), 'error')
+            end
         else
             QBCore.Functions.Notify(Lang:t('error.negative'), 'error')
         end
     end
 end)
+
 
 RegisterNetEvent('qb-pawnshop:client:meltItems', function(item)
     local meltingItem = exports['qb-input']:ShowInput({


### PR DESCRIPTION
**Describe Pull request**
Without this fix, players are able to sell as many of an item as they want, as long as they have at least one. This fixes this issue.

**Questions (please complete the following information):**
- [x]  Have you personally loaded this code into an updated qbcore project and checked all it's functionality?
- [x]  Does your code fit the style guidelines? **yes**
- [x]  Does your PR fit the contribution guidelines? 
